### PR TITLE
fix: add x-access-token to github url to allow pushes

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -185,7 +185,7 @@ runs:
         # Configure git
         git config user.name "sdk-github-actions[bot]"
         git config user.email "sdk-github-actions[bot]@users.noreply.github.com"
-        git config --global url."https://${{ inputs.github-token }}@github.com/".insteadOf "https://github.com/"
+        git config --global url."https://x-access-token:${{ inputs.github-token }}@github.com/".insteadOf "https://github.com/"
 
         # Create branch and push
         branch="${{ inputs.branch-prefix }}-$(date +%Y/%m/%d-%H.%M.%S)"


### PR DESCRIPTION
```
fatal: could not read Password for 'https://***@github.com': No such device or address
Error: Process completed with exit code 128.
```

hit this error when pushing new code to the sdk repo. I updated to use my branch, and it worked

```diff
-      - uses: Sideko-Inc/sdk-update@v1
+      - uses: davidhu2000/sdk-update@main
```